### PR TITLE
Deploy behind an ingress controller

### DIFF
--- a/kubernetes/monitoring-app-ingress.yaml
+++ b/kubernetes/monitoring-app-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: monitoring-app-ingress
+  annotations:
+    traefik.frontend.rule.type: PathPrefix
+    traefik.ingress.kubernetes.io/rewrite-target: /health
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /healthz
+        backend:
+          serviceName: monitoring-app-service
+          servicePort: 80

--- a/kubernetes/monitoring-app-service.yaml
+++ b/kubernetes/monitoring-app-service.yaml
@@ -11,4 +11,4 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 5000
-  type: LoadBalancer
+  type: ClusterIP


### PR DESCRIPTION
Added an ingress resource so it can be deployed behind an ingress controller (over the `/healthz` endpoint to avoid conflict with i.e. Traefik)